### PR TITLE
Organize tutorials

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ link_directories(${rclcpp_LIBRARY_DIRS})
 add_subdirectory(tutorials/move_group_interface)
 
 ament_export_include_directories(include)
-ament_export_dependencies(moveit_core)
-ament_export_dependencies(moveit_visual_tools)
 ament_export_dependencies(moveit_ros_planning_interface)
 ament_export_dependencies(EIGEN3)
+
+ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10.2)
 project(mara_moveit_tutorials)
 
 # Default to C++14
@@ -6,32 +6,37 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
 
-# add_compile_options(-Wall -Wextra -Wpedantic -Werror=ignored-qualifiers)
+find_package(Eigen3 REQUIRED)
+
+# Eigen 3.2 (Wily) only provides EIGEN3_INCLUDE_DIR, not EIGEN3_INCLUDE_DIRS
+if(NOT EIGEN3_INCLUDE_DIRS)
+  set(EIGEN3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
+endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_action REQUIRED)
 find_package(moveit_ros_planning_interface REQUIRED)
 
-include_directories(include)
+find_package(Boost REQUIRED system filesystem date_time thread)
 
-add_executable(move_group_interface_tutorial
-  src/move_group_interface_tutorial.cpp
-)
-ament_target_dependencies(move_group_interface_tutorial
-  rclcpp
-  moveit_ros_planning_interface
-)
+###########
+## Build ##
+###########
 
-target_include_directories(move_group_interface_tutorial PUBLIC
-  ${moveit_ros_planning_interface_INCLUDE_DIRS}
-)
+include_directories(SYSTEM ${THIS_PACKAGE_INCLUDE_DIRS}
+ ${Boost_INCLUDE_DIR}
+ ${EIGEN3_INCLUDE_DIRS})
 
-target_link_libraries(move_group_interface_tutorial
-  ${moveit_ros_planning_interface_LIBRARIES}
-)
+include_directories(${rclcpp_INCLUDE_DIRS}
+ ${moveit_ros_planning_interface_INCLUDE_DIRS})
 
-install(TARGETS
-  move_group_interface_tutorial
-  DESTINATION lib/${PROJECT_NAME}
-)
+link_directories(${rclcpp_LIBRARY_DIRS})
+
+add_subdirectory(tutorials/move_group_interface)
+
+ament_export_include_directories(include)
+ament_export_dependencies(moveit_core)
+ament_export_dependencies(moveit_visual_tools)
+ament_export_dependencies(moveit_ros_planning_interface)
+ament_export_dependencies(EIGEN3)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# mara_moveit_tutorials
+MARA MoveIt tutorials

--- a/package.xml
+++ b/package.xml
@@ -7,6 +7,7 @@
   <!-- Example:  -->
   <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
   <maintainer email="alex@erlerobotics.com">Alejandro</maintainer>
+  <maintainer email="anasarrak@erlerobotics.com">Anas Mchichou</maintainer>
   <!-- One license tag required, multiple allowed, one license per tag -->
   <!-- Commonly used license strings: -->
   <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
@@ -14,9 +15,8 @@
 
   <author>Alejandro Hernandez</author>
 
-  <export>
-    <build_type>ament_cmake</build_type>
-  </export>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
   <!-- <export>
     <moveit_core plugin="${prefix}/mara_manipulator_moveit_ikfast_plugin_description.xml"/>
   </export> -->
@@ -25,4 +25,8 @@
   <depend>moveit_ros_planning_interface</depend>
   <depend>rclcpp</depend>
   <depend>pluginlib</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>

--- a/tutorials/move_group_interface/CMakeLists.txt
+++ b/tutorials/move_group_interface/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(move_group_interface src/move_group_interface_tutorial.cpp)
+target_link_libraries(move_group_interface ${rclcpp_LIBRARIES} ${Boost_LIBRARIES} ${moveit_ros_planning_interface_LIBRARIES})
+install(TARGETS move_group_interface DESTINATION lib/${PROJECT_NAME})

--- a/tutorials/move_group_interface/src/move_group_interface_tutorial.cpp
+++ b/tutorials/move_group_interface/src/move_group_interface_tutorial.cpp
@@ -195,7 +195,7 @@ int main(int argc, char** argv)
   RCLCPP_INFO(node->get_logger(), "Visualizing plan 2 (joint space goal) %s", success ? "" : "FAILED");
 
 
-  printf("%d %d %d\n",  my_plan.start_state_.joint_state.name.size(),  my_plan.start_state_.joint_state.position.size(),  my_plan.start_state_.joint_state.velocity.size());
+  printf("%ld %ld %ld\n",  my_plan.start_state_.joint_state.name.size(),  my_plan.start_state_.joint_state.position.size(),  my_plan.start_state_.joint_state.velocity.size());
 
   for(int i = 0; i < my_plan.start_state_.joint_state.name.size(); i++) {
     printf("%s %.5f\n", my_plan.start_state_.joint_state.name[i].c_str(), my_plan.start_state_.joint_state.position[i]);


### PR DESCRIPTION
Organize the structure, so when adding more tutorials will be easier to enable or disable the one that we want (adding or removing the subdirectory on the cmakelist)